### PR TITLE
chore: different service names on test and production

### DIFF
--- a/infrastructure/iris-gateway/templates/locations-eps/configmap.yaml
+++ b/infrastructure/iris-gateway/templates/locations-eps/configmap.yaml
@@ -4,18 +4,18 @@ metadata:
   name: {{ include "iris-gateway.locations-eps" . }}
 data:
   settings.yml: |
-    name: ls-1
+    name: {{ (index .Values.serviceNames .Values.environment).locations }}
     directory:
       type: api
       settings:
         jsonrpc_client:
           tls:
             ca_certificate_files: [ "{{ .Values.tls.mountPath }}/root.crt" ]
-            certificate_file: "{{ .Values.tls.mountPath }}/ls-1.crt"
-            key_file: "{{ .Values.tls.mountPath }}/ls-1.key"
+            certificate_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).locations }}.crt"
+            key_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).locations }}.key"
         ca_certificate_files: [ "{{ .Values.tls.mountPath }}/root.crt" ]
         endpoints: [ "https://{{ include "iris-gateway.service-directory" . }}:{{ .Values.nodePorts.serviceDirectory }}/jsonrpc" ]
-        server_names: [ "sd-1" ]
+        server_names: [ "{{ (index .Values.serviceNames .Values.environment).serviceDirectory }}" ]
     channels:  # defines all the channels that we want to open when starting the server
       - name: Stdout channel
         type: stdout
@@ -26,8 +26,8 @@ data:
           bind_address: "0.0.0.0:{{ .Values.nodePorts.locationsEps }}"
           tls:
             ca_certificate_files: [ "{{ .Values.tls.mountPath }}/root.crt" ]
-            certificate_file: "{{ .Values.tls.mountPath }}/ls-1.crt"
-            key_file: "{{ .Values.tls.mountPath }}/ls-1.key"
+            certificate_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).locations }}.crt"
+            key_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).locations }}.key"
       - name: main JSON-RPC client  # creates outgoing JSONRPC connections to deliver and receive messages
         type: jsonrpc_client
         settings:
@@ -38,5 +38,5 @@ data:
         settings:
           tls:
             ca_certificate_files: [ "{{ .Values.tls.mountPath }}/root.crt" ]
-            certificate_file: "{{ .Values.tls.mountPath }}/ls-1.crt"
-            key_file: "{{ .Values.tls.mountPath }}/ls-1.key"
+            certificate_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).locations }}.crt"
+            key_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).locations }}.key"

--- a/infrastructure/iris-gateway/templates/public-proxy-eps/configmap.yaml
+++ b/infrastructure/iris-gateway/templates/public-proxy-eps/configmap.yaml
@@ -4,18 +4,18 @@ metadata:
   name: {{ include "iris-gateway.public-proxy-eps" . }}
 data:
   settings.yml: |
-    name: public-proxy-1
+    name: {{ (index .Values.serviceNames .Values.environment).publicProxy }}
     directory:
       type: api
       settings:
         jsonrpc_client:
           tls:
             ca_certificate_files: [ "{{ .Values.tls.mountPath }}/root.crt" ]
-            certificate_file: "{{ .Values.tls.mountPath }}/public-proxy-1.crt"
-            key_file: "{{ .Values.tls.mountPath }}/public-proxy-1.key"
+            certificate_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).publicProxy }}.crt"
+            key_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).publicProxy }}.key"
         ca_certificate_files: [ "{{ .Values.tls.mountPath }}/root.crt" ]
         endpoints: [ "https://{{ include "iris-gateway.service-directory" . }}:{{ .Values.nodePorts.serviceDirectory }}/jsonrpc" ]
-        server_names: [ "sd-1" ]
+        server_names: [ "{{ (index .Values.serviceNames .Values.environment).serviceDirectory }}" ]
     channels:  # defines all the channels that we want to open when starting the server
       - name: Stdout channel
         type: stdout
@@ -26,8 +26,8 @@ data:
           bind_address: "0.0.0.0:{{ .Values.nodePorts.publicProxyEps }}"
           tls:
             ca_certificate_files: [ "{{ .Values.tls.mountPath }}/root.crt" ]
-            certificate_file: "{{ .Values.tls.mountPath }}/public-proxy-1.crt"
-            key_file: "{{ .Values.tls.mountPath }}/public-proxy-1.key"
+            certificate_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).publicProxy }}.crt"
+            key_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).publicProxy }}.key"
       - name: main JSON-RPC client  # creates outgoing JSONRPC connections to deliver and receive messages
         type: jsonrpc_client
         settings:
@@ -35,22 +35,22 @@ data:
           endpoint: https://{{ include "iris-gateway.public-proxy" . }}:{{ .Values.publicProxy.jsonRpcPort }}/jsonrpc
           tls:
             ca_certificate_files: [ "{{ .Values.tls.mountPath }}/root.crt" ]
-            certificate_file: "{{ .Values.tls.mountPath }}/public-proxy-1.crt"
-            key_file: "{{ .Values.tls.mountPath }}/public-proxy-1.key"
-            server_name: public-proxy-1
+            certificate_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).publicProxy }}.crt"
+            key_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).publicProxy }}.key"
+            server_name: {{ (index .Values.serviceNames .Values.environment).publicProxy }}
       - name: main gRPC client # creates outgoing gRPC connections to deliver and receive messages
         type: grpc_client
         settings:
           tls:
             ca_certificate_files: [ "{{ .Values.tls.mountPath }}/root.crt" ]
-            certificate_file: "{{ .Values.tls.mountPath }}/public-proxy-1.crt"
-            key_file: "{{ .Values.tls.mountPath }}/public-proxy-1.key"
+            certificate_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).publicProxy }}.crt"
+            key_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).publicProxy }}.key"
       - name: main JSON-RPC server # accepts incoming JSONRPC connections to deliver and receive messages
         type: jsonrpc_server
         settings:
           bind_address: "0.0.0.0:{{ .Values.publicProxyEps.jsonRpcPort }}"
           tls:
             ca_certificate_files: [ "{{ .Values.tls.mountPath }}/root.crt" ]
-            certificate_file: "{{ .Values.tls.mountPath }}/public-proxy-1.crt"
-            key_file: "{{ .Values.tls.mountPath }}/public-proxy-1.key"
+            certificate_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).publicProxy }}.crt"
+            key_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).publicProxy }}.key"
             verify_client: false

--- a/infrastructure/iris-gateway/templates/public-proxy/configmap.yaml
+++ b/infrastructure/iris-gateway/templates/public-proxy/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   settings.yml: |
     public:
-      name: public-proxy-1
+      name: {{ (index .Values.serviceNames .Values.environment).publicProxy }}
       database_file: {{ .Values.publicProxy.persistentStoragePath }}/public-proxy-announcements.db
       tls_bind_address: 0.0.0.0:{{ .Values.nodePorts.publicProxyTls }}
       internal_bind_address: 0.0.0.0:{{ .Values.nodePorts.publicProxyInternal }}
@@ -13,14 +13,14 @@ data:
       jsonrpc_client:
         endpoint: https://{{ include "iris-gateway.public-proxy-eps" . }}:{{ .Values.publicProxyEps.jsonRpcPort }}/jsonrpc
         tls:
-          certificate_file: "{{ .Values.tls.mountPath }}/public-proxy-1.crt"
-          key_file: "{{ .Values.tls.mountPath }}/public-proxy-1.key"
+          certificate_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).publicProxy }}.crt"
+          key_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).publicProxy }}.key"
           ca_certificate_files: [ "{{ .Values.tls.mountPath }}/root.crt" ]
-          server_name: public-proxy-1
+          server_name: {{ (index .Values.serviceNames .Values.environment).publicProxy }}
       jsonrpc_server: # the JSON-RPC server that the EPS server uses for communication
         bind_address: "0.0.0.0:{{ .Values.publicProxy.jsonRpcPort }}"
         tls:
           ca_certificate_files: [ "{{ .Values.tls.mountPath }}/root.crt" ]
-          certificate_file: "{{ .Values.tls.mountPath }}/public-proxy-1.crt"
-          key_file: "{{ .Values.tls.mountPath }}/public-proxy-1.key"
+          certificate_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).publicProxy }}.crt"
+          key_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).publicProxy }}.key"
           verify_client: false

--- a/infrastructure/iris-gateway/templates/service-directory/configmap.yaml
+++ b/infrastructure/iris-gateway/templates/service-directory/configmap.yaml
@@ -8,8 +8,8 @@ data:
       bind_address: "0.0.0.0:{{ .Values.nodePorts.serviceDirectory }}"
       tls:
         ca_certificate_files: [ "{{ .Values.tls.mountPath }}/root.crt" ]
-        certificate_file: "{{ .Values.tls.mountPath }}/sd-1.crt"
-        key_file: "{{ .Values.tls.mountPath }}/sd-1.key"
+        certificate_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).serviceDirectory }}.crt"
+        key_file: "{{ .Values.tls.mountPath }}/{{ (index .Values.serviceNames .Values.environment).serviceDirectory }}.key"
     directory:
       database_file: {{ .Values.serviceDirectory.persistentStoragePath }}/service-directory.records
       ca_certificate_files: [ "{{ .Values.tls.mountPath }}/root.crt" ]

--- a/infrastructure/iris-gateway/values.yaml
+++ b/infrastructure/iris-gateway/values.yaml
@@ -18,6 +18,16 @@ nodePorts:
   publicProxyInternal: 32326
   publicProxyEps: 32327
 
+serviceNames:
+  test:
+    locations: ls-1
+    publicProxy: public-proxy-1
+    serviceDirectory: sd-1
+  production:
+    locations: locations-production-1
+    publicProxy: public-proxy-production-1
+    serviceDirectory: service-directory-production-1
+
 eps:
   image: inoeg/eps
   configMountPath: /config


### PR DESCRIPTION
So that names don't collide for different environments to avoid mix-ups.