### PR TITLE
Adjust open file descriptor threshold

### DIFF
--- a/infrastructure/iris-gateway/templates/monitoring/alerts.yaml
+++ b/infrastructure/iris-gateway/templates/monitoring/alerts.yaml
@@ -25,7 +25,7 @@ spec:
             receiver: iris-alerts-{{ .Values.environment }}
             severity: warning
         - alert: OpenFileDescriptorsTooHigh
-          expr: sum(process_open_fds{namespace="iris-gateway"}) > 1024
+          expr: sum(process_open_fds{namespace="iris-gateway"}) > 2048
           annotations:
             message: "Too many open files in namespace iris-gateway : {{ "{{ $value }}" }}"
             summary: Open filedescriptors too high


### PR DESCRIPTION
Can be set to 2k. I think there is more traffic now.