### PR TITLE
chore: sets eps version to 0.1.63_2 with non-root images

### DIFF
--- a/infrastructure/iris-gateway/values.yaml
+++ b/infrastructure/iris-gateway/values.yaml
@@ -3,7 +3,7 @@
 #   production: --set environment=production
 environment: undefined
 
-epsRepoTag: v0.1.61
+epsRepoTag: v0.1.63_2
 
 tls:
   keystoreSecretName: tls-keystore


### PR DESCRIPTION
Refs iris-connect/iris-backlog#224