### PR TITLE
updated batch/v1beta1 to batch/v1

### DIFF
--- a/infrastructure/iris-gateway/templates/locations-postgres-backup/cronjob.yaml
+++ b/infrastructure/iris-gateway/templates/locations-postgres-backup/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "iris-gateway.locations-postgres-backup" . }}

--- a/infrastructure/iris-gateway/templates/service-directory-backup/cronjob.yaml
+++ b/infrastructure/iris-gateway/templates/service-directory-backup/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "iris-gateway.service-directory-backup" . }}


### PR DESCRIPTION
batch/v1beta1 will be Unavailable with K8s version 1.25, updated it now so no more deprecation warning