### PR TITLE
fix(HD Search): adds `getAllHds` and improves the pervormance of the …

### DIFF
--- a/iris-backend-service/src/main/java/iris/backend_service/hd_search/HdSearchRpcService.java
+++ b/iris-backend-service/src/main/java/iris/backend_service/hd_search/HdSearchRpcService.java
@@ -11,7 +11,13 @@ import com.googlecode.jsonrpc4j.JsonRpcParam;
 public interface HdSearchRpcService {
 
 	List<HealthDepartmentDto> searchForHd(@Valid @JsonRpcParam(value = "_client") JsonRpcClientDto client,
-			@JsonRpcParam(value = "searchKeyword") String searchKeyword);
+			@JsonRpcParam(value = "searchKeyword") String searchKeyword,
+			@JsonRpcParam(value = "withDetails") boolean withDetails,
+			@JsonRpcParam(value = "alsoNotConnectedHds") boolean alsoNotConnected);
+
+	List<HealthDepartmentDto> getAllHds(@Valid @JsonRpcParam(value = "_client") JsonRpcClientDto client,
+			@JsonRpcParam(value = "withDetails") boolean withDetails,
+			@JsonRpcParam(value = "alsoNotConnectedHds") boolean alsoNotConnected);
 
 	record HealthDepartmentDto(String name,
 			String rkiCode,

--- a/iris-backend-service/src/main/java/iris/backend_service/hd_search/HdSearchRpcServieImpl.java
+++ b/iris-backend-service/src/main/java/iris/backend_service/hd_search/HdSearchRpcServieImpl.java
@@ -8,12 +8,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 import org.springframework.stereotype.Service;
+
+import com.googlecode.jsonrpc4j.JsonRpcParam;
 
 @Service
 @RequiredArgsConstructor
@@ -25,33 +28,113 @@ class HdSearchRpcServieImpl implements HdSearchRpcService {
 	private final @NotNull AlertService alerts;
 
 	@Override
-	public List<HealthDepartmentDto> searchForHd(@Valid JsonRpcClientDto client, @NotEmpty String searchKeyword) {
+	public List<HealthDepartmentDto> searchForHd(@Valid JsonRpcClientDto client,
+			@NotEmpty String searchKeyword,
+			boolean withDetails,
+			boolean alsoNotConnected) {
 
 		var hds = healthDepartments.findDepartmentsContains(searchKeyword);
 
-		log.debug("JSON-RPC - Client {} searchs HD for: {} ⇒ found: {}", client.getName(), searchKeyword, hds.size());
+		var result = hds.parallelStream()
+				.map(it -> mapToDto(it, withDetails, alsoNotConnected))
+				.flatMap(Optional::stream)
+				.toList();
 
-		return hds.stream().map(this::mapToDto).toList();
+		log.debug("JSON-RPC - Client {} searchs HD for: {} (with details: {}; also not connected HDs: {}) ⇒ found: {}",
+				client.getName(), searchKeyword, Boolean.toString(withDetails), Boolean.toString(alsoNotConnected),
+				result.size());
+
+		return result;
 	}
 
-	private HealthDepartmentDto mapToDto(HealthDepartment hd) {
+	@Override
+	public List<HealthDepartmentDto> getAllHds(
+			@Valid @JsonRpcParam(value = "_client") JsonRpcClientDto client,
+			boolean withDetails,
+			boolean alsoNotConnected) {
 
-		var epsName = config.getHdNameFor(hd.getCode()).orElse(null);
+		var hds = healthDepartments.getAll();
 
-		var baseAddress = hd.getAddress();
-		var address = new Address(baseAddress.getStreet(), baseAddress.getZipCode(), baseAddress.getPlace());
+		var result = hds.parallelStream()
+				.map(it -> mapToDto(it, withDetails, alsoNotConnected))
+				.flatMap(Optional::stream)
+				.toList();
 
-		var contact = new ContactData(hd.getPhone(), hd.getFax(), hd.getEmail());
+		log.debug("JSON-RPC - Client {} get all HDs (with details: {}; also not connected HDs: {}) ⇒ found: {}",
+				client.getName(), Boolean.toString(withDetails), Boolean.toString(alsoNotConnected), result.size());
 
-		var covid19ContactData = hd.getCovid19ContactData();
-		var covidContact = new ContactData(covid19ContactData.getHotline(), covid19ContactData.getFax(),
-				covid19ContactData.getEmail());
+		return result;
+	}
 
-		var entryContactData = hd.getEinreiseContactData();
-		var entryContact = new ContactData(entryContactData.getHotline(), entryContactData.getFax(),
-				entryContactData.getEmail());
+	private Optional<HealthDepartmentDto> mapToDto(HealthDepartment hd, boolean withDetails, boolean alsoNotConnected) {
 
-		return new HealthDepartmentDto(hd.getName(), hd.getCode(), epsName, hd.getDepartment(), address, contact,
-				covidContact, entryContact);
+		var code = hd.getCode();
+		var epsName = config.getHdNameFor(code);
+
+		var dto = epsName.map(it -> createHealthDepartmentDto(hd, withDetails, code, it));
+
+		if (alsoNotConnected) {
+			dto = dto.or(() -> Optional.of(createHealthDepartmentDto(hd, withDetails, code, null)));
+		}
+
+		return dto;
+	}
+
+	private HealthDepartmentDto createHealthDepartmentDto(HealthDepartment hd, boolean withDetails, String code,
+			String epsName) {
+
+		return new HealthDepartmentDto(hd.getName(),
+				code,
+				epsName,
+				mapToDepartment(hd, withDetails),
+				mapToAddress(hd, withDetails),
+				mapToContact(hd, withDetails),
+				mapToCovidContact(hd, withDetails),
+				mapToEntryContact(hd, withDetails));
+	}
+
+	private String mapToDepartment(HealthDepartment hd, boolean withDetails) {
+
+		if (withDetails) {
+			return hd.getDepartment();
+		}
+		return null;
+	}
+
+	private Address mapToAddress(HealthDepartment hd, boolean withDetails) {
+
+		if (withDetails) {
+			var baseAddress = hd.getAddress();
+			return new Address(baseAddress.getStreet(), baseAddress.getZipCode(), baseAddress.getPlace());
+		}
+		return null;
+	}
+
+	private ContactData mapToContact(HealthDepartment hd, boolean withDetails) {
+
+		if (withDetails) {
+			return new ContactData(hd.getPhone(), hd.getFax(), hd.getEmail());
+		}
+		return null;
+	}
+
+	private ContactData mapToCovidContact(HealthDepartment hd, boolean withDetails) {
+
+		if (withDetails) {
+			var covid19ContactData = hd.getCovid19ContactData();
+			return new ContactData(covid19ContactData.getHotline(), covid19ContactData.getFax(),
+					covid19ContactData.getEmail());
+		}
+		return null;
+	}
+
+	private ContactData mapToEntryContact(HealthDepartment hd, boolean withDetails) {
+
+		if (withDetails) {
+			var entryContactData = hd.getEinreiseContactData();
+			return new ContactData(entryContactData.getHotline(), entryContactData.getFax(),
+					entryContactData.getEmail());
+		}
+		return null;
 	}
 }


### PR DESCRIPTION
…HD search with `searchForHd`

- Adds the boolean param `withDetails` to the method `searchForHd` to switch between a basic and a full data view. The basic view contains only `name`, `rkiCode` and `epsName`.
- Adds the boolean param `alsoNotConnectedHds` to the method `searchForHd` to enable if the hds without an `epsName` (these are not connected to EPS) include into the response list or not.
- Adds the method `getAllHds` to get a list of all infos about health departments from RKI data. This method has also the parameter `withDetails` and `alsoNotConnectedHds`.

When reading data from the RKI XML with XML Beam, each read costs time and the less data that needs to be read/fetched, the faster the search and processing goes. Therefore, the processing can be accelerated very significantly with the two parameters.

**It should always be loaded as little data as possible and best both parameters should be set to FALSE.

Further optimizations were made in the code to load data from the XML only once and only when it is really needed.

Refs iris-connect/iris-client#678