### PR TITLE
fix: RPC methods can now be extended with additional parameters while…

### DIFF
--- a/iris-backend-service/src/main/java/iris/backend_service/config/ServiceEndpointsConfig.java
+++ b/iris-backend-service/src/main/java/iris/backend_service/config/ServiceEndpointsConfig.java
@@ -30,6 +30,7 @@ public class ServiceEndpointsConfig {
 		var compositeJsonServiceExporter = new CompositeJsonServiceExporter();
 		compositeJsonServiceExporter.setServices(new Object[] { health, locations, alerts, configurations, hdSearch });
 		compositeJsonServiceExporter.setAllowExtraParams(true);
+		compositeJsonServiceExporter.setAllowLessParams(true);
 
 		return compositeJsonServiceExporter;
 	}


### PR DESCRIPTION
… still remaining compatible with legacy RPC clients if default values are used.

Refs iris-connect/iris-backlog#278